### PR TITLE
Fixed a bug where the PartOpacity property did not work properly

### DIFF
--- a/src/motion/cubismmotion.ts
+++ b/src/motion/cubismmotion.ts
@@ -393,18 +393,10 @@ export class CubismMotion extends ACubismMotion {
       CubismMotionCurveTarget.CubismMotionCurveTarget_PartOpacity;
       ++c
     ) {
-      // Find parameter index.
-      parameterIndex = model.getParameterIndex(curves[c].id);
-
-      // Skip curve evaluation if no value in sink.
-      if (parameterIndex == -1) {
-        continue;
-      }
-
       // Evaluate curve and apply value.
       value = evaluateCurve(this._motionData, c, time);
 
-      model.setParameterValueByIndex(parameterIndex, value);
+      model.setPartOpacityById(curves[c].id, value);
     }
 
     if (timeOffsetSeconds >= this._motionData.duration) {


### PR DESCRIPTION
# Bug reproduce
when you load the following live2d model
- from github: [Ava](https://github.com/eipip1e0/BlogCDN/tree/master/Blog/live2d/Cubsim4/Ava)
- from zip: [Ava.zip](https://github.com/guansss/CubismWebFramework/files/8675138/Ava.zip)
